### PR TITLE
Quick bugfix: `v` -> `arg`

### DIFF
--- a/src/JuliaVariables.jl
+++ b/src/JuliaVariables.jl
@@ -305,7 +305,7 @@ function solve(ana, ex, ctx_flag::CtxFlag = CtxFlag())
                     @when Expr(:(=), k::Symbol, v) = arg begin
                         Expr(:(=), k, solve(ana, v, ctx_flag))
                     @otherwise
-                        solve(ana, v, ctx_flag)
+                        solve(ana, arg, ctx_flag)
                     end
                 end
                 Expr(:tuple, args...)


### PR DESCRIPTION
The `v` after `@otherwise` was throwing an error. This seems to fix it:

```julia
        Expr(:tuple, args...) =>
            let args = map(args) do arg
                    @when Expr(:(=), k::Symbol, v) = arg begin
                        Expr(:(=), k, solve(ana, v, ctx_flag))
                    @otherwise
                        solve(ana, arg, ctx_flag)
                    end
                end
                Expr(:tuple, args...)
            end
```