### PR TITLE
Add unique_id field to Var

### DIFF
--- a/src/JuliaVariables.jl
+++ b/src/JuliaVariables.jl
@@ -483,9 +483,9 @@ function solve!(ast; toplevel=true)
     function from_symref(s::SymRef)
         id[s.sym] = get(id, s.sym, 0) + 1
         s.as_non_sym && return s.sym
-        s.ana === nothing && return Var(s.sym, true, true, true)
+        s.ana === nothing && return Var(s.sym, s.sym, true, true, true)
         var = s.ana.solved[s.sym]
-        var isa Symbol && return Var(var, true, true, true)
+        var isa Symbol && return Var(var, var, true, true, true)
         local_var_to_var(var)
     end
 

--- a/src/JuliaVariables.jl
+++ b/src/JuliaVariables.jl
@@ -59,7 +59,7 @@ SymRef(sym::Symbol, ana::Union{Nothing, Analyzer}) = SymRef(sym, ana, false)
 
 struct Var
     name::Symbol
-    unique_id::Symbol
+    unique_id:: Union{Ref{Bool}, Nothing}  # nothing when it's a global variable
     is_mutable::Bool
     is_shared::Bool
     is_global::Bool
@@ -444,8 +444,7 @@ function solve!(ast; toplevel=true)
         end
 
     function local_var_to_var(var::LocalVar)::Var
-        unique_id = Symbol(var.sym, "_", id[var.sym])
-        @show unique_id # Remove after demo
+        unique_id = var.is_shared
         Var(var.sym, unique_id, var.is_mutable[], var.is_shared[], false)
     end
 
@@ -483,9 +482,9 @@ function solve!(ast; toplevel=true)
     function from_symref(s::SymRef)
         id[s.sym] = get(id, s.sym, 0) + 1
         s.as_non_sym && return s.sym
-        s.ana === nothing && return Var(s.sym, s.sym, true, true, true)
+        s.ana === nothing && return Var(s.sym, nothing, true, true, true)
         var = s.ana.solved[s.sym]
-        var isa Symbol && return Var(var, var, true, true, true)
+        var isa Symbol && return Var(var, nothing, true, true, true)
         local_var_to_var(var)
     end
 


### PR DESCRIPTION
Closes https://github.com/JuliaStaging/JuliaVariables.jl/issues/28

For demonstration, I temporarily added the `@show` line here:
```julia
    function local_var_to_var(var::LocalVar)::Var
        unique_id = Symbol(var.sym, "_", id[var.sym])
        @show unique_id # Remove after demo
        Var(var.sym, unique_id, var.is_mutable[], var.is_shared[], false)
    end
```

Then for example,
```julia
julia> quote
           x = 1
           function (a)
               x = 1
           end
       end |>  solve_from_local
unique_id = :x_1
unique_id = :x_2
unique_id = :a_1
unique_id = :x_2
unique_id = :x_2
:($(Expr(:scoped, (bounds = Var[mut @shared x], freevars = Var[], bound_inits = Symbol[]), quote
    #= REPL[19]:2 =#
    mut @shared x = 1
    #= REPL[19]:3 =#
    function (a,)
        $(Expr(:scoped, (bounds = Var[@local a], freevars = Var[mut @shared x], bound_inits = [:a]), quote
    #= REPL[19]:3 =#
    #= REPL[19]:4 =#
    mut @shared x = 1
end))
    end
end)))
```

This PR changes `Var` to
```julia
struct Var
    name::Symbol
    unique_id::Symbol
    is_mutable::Bool
    is_shared::Bool
    is_global::Bool
end
```
The `unique_id` field is not displayed, but can easily be used downstream for refactoring local variables.